### PR TITLE
feat: expose form interface type

### DIFF
--- a/src/Formality.re
+++ b/src/Formality.re
@@ -8,6 +8,14 @@ module FormStatus = Formality__FormStatus;
 module Make = Formality__Form.Make;
 module MakeWithId = Formality__FormWithId.Make;
 
+type interface('state, 'submissionError, 'field, 'message) =
+  Formality__FormWithId.genericInterface(
+    'state,
+    'submissionError,
+    'field,
+    'message,
+  );
+
 module Async = {
   include Formality__Validation.Async;
 

--- a/src/Formality.rei
+++ b/src/Formality.rei
@@ -5,6 +5,14 @@ module FormStatus = Formality__FormStatus;
 module Make = Formality__Form.Make;
 module MakeWithId = Formality__FormWithId.Make;
 
+type interface('state, 'submissionError, 'field, 'message) =
+  Formality__FormWithId.genericInterface(
+    'state,
+    'submissionError,
+    'field,
+    'message,
+  );
+
 type ok = Formality__Validation.Result.ok = | Valid | NoValue;
 
 type result('message) = Belt.Result.t(ok, 'message);

--- a/src/Formality__FormWithId.re
+++ b/src/Formality__FormWithId.re
@@ -3,6 +3,22 @@ module Strategy = Formality__Strategy;
 module FormStatus = Formality__FormStatus;
 module ReactUpdate = Formality__ReactUpdate;
 
+type genericInterface('state, 'submissionError, 'field, 'message) = {
+  state: 'state,
+  status: FormStatus.t('submissionError),
+  result: 'field => option(Validation.Result.result('message)),
+  dirty: unit => bool,
+  valid: unit => bool,
+  submitting: bool,
+  change: ('field, 'state) => unit,
+  blur: 'field => unit,
+  submit: unit => unit,
+  mapSubmissionError: ('submissionError => 'submissionError) => unit,
+  dismissSubmissionError: unit => unit,
+  dismissSubmissionResult: unit => unit,
+  reset: unit => unit,
+};
+
 module type Form = {
   type field;
   type state;
@@ -45,21 +61,13 @@ module Make = (Form: Form) => {
     | DismissSubmissionResult
     | Reset;
 
-  type interface = {
-    state: Form.state,
-    status: FormStatus.t(Form.submissionError),
-    result: Form.field => option(Validation.Result.result(Form.message)),
-    dirty: unit => bool,
-    valid: unit => bool,
-    submitting: bool,
-    change: (Form.field, Form.state) => unit,
-    blur: Form.field => unit,
-    submit: unit => unit,
-    mapSubmissionError: (Form.submissionError => Form.submissionError) => unit,
-    dismissSubmissionError: unit => unit,
-    dismissSubmissionResult: unit => unit,
-    reset: unit => unit,
-  };
+  type interface =
+    genericInterface(
+      Form.state,
+      Form.submissionError,
+      Form.field,
+      Form.message,
+    );
 
   let getInitialState = input => {
     input,


### PR DESCRIPTION
This PR exports the form.interface record type as a generic type. This is useful for creating re-usable form UI components that you can share across forms.