### PR TITLE
Fix stack overflow

### DIFF
--- a/lib/ppx/AstHelpers.re
+++ b/lib/ppx/AstHelpers.re
@@ -344,3 +344,8 @@ module E = {
       (~validators, ~collection: Collection.t, ~loc, field) =>
     field |> field3(~in_=(validators, collection.plural, "fields"), ~loc);
 };
+
+// Disables warning 4 to prevent stack overflow
+// Details: https://github.com/BuckleScript/bucklescript/issues/4327
+let warning_4_disable = (~loc) =>
+  Attr.mk("warning" |> str(~loc), PStr([[%stri "-4"]]));

--- a/lib/ppx/Form_UseFormFn.re
+++ b/lib/ppx/Form_UseFormFn.re
@@ -21,6 +21,7 @@ let ast = (~scheme: Scheme.t, ~async: bool, ~loc) => [%stri
           %e
           {
             Exp.match(
+              ~attrs=[warning_4_disable(~loc)],
               [%expr action],
               Form_UseFormFn_RestActions.ast(~loc, ~async)
               |> List.rev_append(

--- a/lib/ppx/Form_UseFormFn_Interface.re
+++ b/lib/ppx/Form_UseFormFn_Interface.re
@@ -166,7 +166,7 @@ let ast = (~scheme: Scheme.t, ~async: bool, ~loc) => {
 
     let match_exp =
       Exp.match(
-        ~attrs=[Dirty.warning_4_disable(~loc)],
+        ~attrs=[warning_4_disable(~loc)],
         [%expr state.fieldsStatuses],
         [no_case, yes_case],
       );

--- a/lib/ppx/Form_ValidateFormFn.re
+++ b/lib/ppx/Form_ValidateFormFn.re
@@ -575,7 +575,11 @@ let validate_fields_of_collection_in_sync_form =
         index,
       ) => {
       %e
-      Exp.match(match_values, [ok_case, error_case])
+      Exp.match(
+        ~attrs=[warning_4_disable(~loc)],
+        match_values,
+        [ok_case, error_case],
+      )
     });
   };
 };
@@ -795,7 +799,11 @@ let validate_fields_of_collection_in_async_form =
         index,
       ) => {
       %e
-      Exp.match(match_values, [validating_case, ok_case, error_case])
+      Exp.match(
+        ~attrs=[warning_4_disable(~loc)],
+        match_values,
+        [validating_case, ok_case, error_case],
+      )
     });
   };
 };
@@ -1151,7 +1159,11 @@ module Sync = {
                            Exp.case(pat, expr);
                          };
 
-                         Exp.match(match_values, [ok_case, error_case]);
+                         Exp.match(
+                           ~attrs=[warning_4_disable(~loc)],
+                           match_values,
+                           [ok_case, error_case],
+                         );
                        };
                      }
                    ],
@@ -1588,7 +1600,11 @@ module Async = {
             Exp.case(pat, expr);
           };
 
-          Exp.match(match_values, [validating_case, ok_case, error_case]);
+          Exp.match(
+            ~attrs=[warning_4_disable(~loc)],
+            match_values,
+            [validating_case, ok_case, error_case],
+          );
         };
       }
     ];

--- a/lib/test/Test.re
+++ b/lib/test/Test.re
@@ -42,6 +42,7 @@ let () =
             "Ok__Message",
             "Ok__SubmissionError",
             "Ok__Include",
+            "Ok__LargeFormWithValidators",
           ]
           |> List.rev
           |> List.rev_map(ok),

--- a/lib/test/cases/Ok__LargeFormWithValidators.re
+++ b/lib/test/cases/Ok__LargeFormWithValidators.re
@@ -1,0 +1,129 @@
+module Form = [%form
+  type submissionError =
+    | CouldNotSubmit;
+  type input = {
+    booleanField1: bool,
+    booleanField2: bool,
+    booleanField3: bool,
+    dateField1: Js.Date.t,
+    dateField2: Js.Date.t,
+    intField1: string,
+    intField2: string,
+    intField3: string,
+    intField4: string,
+    intField5: string,
+    optionalStringField1: string,
+    optionalStringField2: string,
+    readOnlyField1: string,
+    readOnlyField2: string,
+    stringField1: string,
+    stringField2: string,
+    stringField3: string,
+    stringField4: string,
+  };
+  type output = {
+    booleanField1: bool,
+    booleanField2: bool,
+    booleanField3: bool,
+    dateField1: Js.Date.t,
+    dateField2: Js.Date.t,
+    intField1: int,
+    intField2: int,
+    intField3: int,
+    intField4: int,
+    intField5: int,
+    optionalStringField1: option(string),
+    optionalStringField2: option(string),
+    readOnlyField1: unit,
+    readOnlyField2: unit,
+    stringField1: string,
+    stringField2: string,
+    stringField3: string,
+    stringField4: string,
+  };
+  let validators = {
+    booleanField1: None,
+    booleanField2: None,
+    booleanField3: {
+      strategy: OnFirstBlur,
+      validate: form => Ok(form.booleanField3),
+    },
+    dateField1: {
+      strategy: OnFirstChange,
+      validate: form => Ok(form.dateField1),
+    },
+    dateField2: {
+      strategy: OnFirstChange,
+      validate: form => Ok(form.dateField2),
+    },
+    intField1: {
+      strategy: OnFirstBlur,
+      validate: form =>
+        switch (form.intField1 |> int_of_string_opt) {
+        | Some(x) => Ok(x)
+        | None => Error("Invalid number")
+        },
+    },
+    intField2: {
+      strategy: OnFirstBlur,
+      validate: form =>
+        switch (form.intField2 |> float_of_string_opt) {
+        | Some(x) => Ok(x |> int_of_float)
+        | None => Error("Invalid number")
+        },
+    },
+    intField3: {
+      strategy: OnFirstBlur,
+      validate: form =>
+        switch (form.intField3 |> int_of_string_opt) {
+        | Some(x) => Ok(x)
+        | None => Error("Invalid number")
+        },
+    },
+    intField4: {
+      strategy: OnFirstBlur,
+      validate: form =>
+        switch (form.intField4 |> float_of_string_opt) {
+        | Some(x) => Ok(x |> int_of_float)
+        | None => Error("Invalid number")
+        },
+    },
+    intField5: {
+      strategy: OnFirstBlur,
+      validate: foo =>
+        switch (foo.intField5 |> float_of_string_opt) {
+        | Some(x) => Ok(x |> int_of_float)
+        | None => Error("Invalid number")
+        },
+    },
+    optionalStringField1: {
+      strategy: OnFirstBlur,
+      validate: form => Ok(Some(form.optionalStringField1)),
+    },
+    optionalStringField2: {
+      strategy: OnFirstBlur,
+      validate: form => Ok(Some(form.optionalStringField2)),
+    },
+    readOnlyField1: {
+      strategy: OnFirstBlur,
+      validate: _ => Ok(),
+    },
+    readOnlyField2: {
+      strategy: OnFirstBlur,
+      validate: _ => Ok(),
+    },
+    stringField1: None,
+    stringField2: {
+      strategy: OnFirstBlur,
+      validate: form => Ok(form.stringField2),
+    },
+    stringField3: {
+      strategy: OnFirstBlur,
+      validate: form => Ok(form.stringField3),
+    },
+    stringField4: {
+      strategy: OnFirstBlur,
+      validate: form => Ok(form.stringField4),
+    },
+  }
+];


### PR DESCRIPTION
Forms that have a large number of fields were causing stack overflows if warning 4 was enabled ([related](https://github.com/ocaml/ocaml/pull/9511)).

There was other issues with stack overflows that were [fixed previously](https://github.com/MinimaHQ/re-formality/commit/061a84b19e1a79106b7e3419ccea17d5a2d08d9f#diff-4e772ef472e3be04a9172b032f6eb020R126) and the fix for this was to further disable that warning on all `Ast_helper.Exp.match` calls throughout the library.