### PR TITLE
Updates rescript syntax in docs

### DIFF
--- a/docs/03-IO.md
+++ b/docs/03-IO.md
@@ -10,7 +10,7 @@ type input = {email: string};
 type output = {email: Email.t};
 ```
 
-To turn the former into the latter, you must define function, which takes `input` and returns `result`: either `Ok<Email.t>` or `Error<message>`. More on this, in the next sections.
+To turn the former into the latter, you must define function, which takes `input` and returns `result`: either `Ok(Email.t)` or `Error(message)`. More on this, in the next sections.
 
 ---
 

--- a/docs/03-IO.md
+++ b/docs/03-IO.md
@@ -10,7 +10,7 @@ type input = {email: string};
 type output = {email: Email.t};
 ```
 
-To turn the former into the latter, you must define function, which takes `input` and returns `result`: either `Ok(Email.t)` or `Error(message)`. More on this, in the next sections.
+To turn the former into the latter, you must define function, which takes `input` and returns `result`: either `Ok<Email.t>` or `Error<message>`. More on this, in the next sections.
 
 ---
 

--- a/docs/05-AsyncValidation.md
+++ b/docs/05-AsyncValidation.md
@@ -10,15 +10,15 @@ To implement debounced async validations, you need to annotate your input field:
 
 ```reason
 type input = {
-  email: [@field.async] string,
+  email: @field.async string,
 };
 ```
 
-And update the validator: in addition to the `strategy` and `validate` entries, add `validateAsync` function which takes value of `output` type of the field and returns `Js.Promise.t(result([OUTPUT_TYPE_OF_FIELD], message))`. In case of the `email` field, it would be `Js.Promise.t(result(Email.t, message))`.
+And update the validator: in addition to the `strategy` and `validate` entries, add `validateAsync` function which takes value of `output` type of the field and returns `Js.Promise.t<result<[OUTPUT_TYPE_OF_FIELD], message>>`. In case of the `email` field, it would be `Js.Promise.t<result<Email.t, message>>`.
 
 ```reason
 type input = {
-  email: [@field.async] string,
+  email: @field.async string,
 };
 
 type output = {
@@ -47,9 +47,9 @@ let validators = {
 On the rendering side of things, there is only one change. The type of field result is a bit different:
 
 ```reason
-type asyncFieldStatus('outputValue, 'message) =
+type asyncFieldStatus<'outputValue, 'message> =
   | Validating('outputValue)
-  | Result(result('outputValue, 'message));
+  | Result(result<'outputValue, 'message>);
 ```
 
 So in UI it would look like this:
@@ -121,7 +121,7 @@ If you want to trigger async validations on blur, define mode explicitly:
 
 ```reason
 type input = {
-  email: [@field.async {mode: OnBlur}] string,
+  email: @field.async({mode: OnBlur}) string,
 };
 ```
 

--- a/docs/06-Collections.md
+++ b/docs/06-Collections.md
@@ -2,25 +2,25 @@
 Collection is an array that contains sets of fields that can be added or removed from a form.
 
 ## Configuration
-To define a collection, you need to annotate a field in the `input` record with `[@field.collection]` attribute:
+To define a collection, you need to annotate a field in the `input` record with `@field.collection` attribute:
 
 ```reason
-type input = {
-  authors: [@field.collection] array(author),
+type rec input = {
+  authors: @field.collection array<author>,
 }
 and author = {name: string};
 ```
 
 Such field has few requirements:
-1. It must be of `array(entry)` type
+1. It must be of `array<entry>` type
 2. `entry` type must be a record which definition is inlined in the configuration module
-3. `[@field.collection]` can't be combined with other attributes but each field in `entry` record can be handled as any other field in the `input` record. E.g. you can do this:
+3. `@field.collection` can't be combined with other attributes but each field in `entry` record can be handled as any other field in the `input` record. E.g. you can do this:
 
 ```reason
-type input = {
-  authors: [@field.collection] array(author),
+type rec input = {
+  authors: @field.collection array<author>,
 }
-and author = {name: [@field.async] string};
+and author = {name: @field.async string};
 ```
 
 Also, make sure the naming is consistent. E.g. annotated `authors` field (plural) holds an array of `author` records (singular).
@@ -28,13 +28,13 @@ Also, make sure the naming is consistent. E.g. annotated `authors` field (plural
 When the `output` type is different, the implementation might look like this:
 
 ```reason
-type input = {
-  authors: [@field.collection] array(author),
+type rec input = {
+  authors: @field.collection array<author>,
 }
 and author = {name: string};
 
-type output = {
-  authors: array(author'),
+type rec output = {
+  authors: array<author'>,
 }
 and author' = {name: Author.name};
 ```
@@ -43,9 +43,9 @@ Collection validator has the following shape:
 
 ```reason
 authors: {
-  collection: input => result(unit, message),
+  collection: input => result<unit, message>,
   fields: {
-    name: (input, ~at: int) => result([OUTPUT_TYPE_OF_FIELD], message),
+    name: (input, ~at: int) => result<[OUTPUT_TYPE_OF_FIELD], message>,
   }
 }
 ```

--- a/docs/07-DependentFields.md
+++ b/docs/07-DependentFields.md
@@ -8,7 +8,7 @@ type input = {
 };
 ```
 
- In the case above, it states: "If the value of field `a` has changed, please, re-validate field `b` as well".
+In the case above, it states: "If the value of field `a` has changed, please, re-validate field `b` as well".
 
 A real-world use-case is a form that updates a password:
 
@@ -35,7 +35,7 @@ type input = {
 If one of the dependent fields is a field of collection, define it like this:
 
 ```reason
-type input = {
+type rec input = {
   title: [@field.deps author.name] string,
   authors: [@field.collection] array(author),
 }

--- a/docs/08-Metadata.md
+++ b/docs/08-Metadata.md
@@ -1,5 +1,5 @@
 # Metadata
-Sometimes, to perform validation and return a proper type as an output you need something else besides a form state. For example, there is an array of categories `array(Category.t)` that comes from your server and you need to validate that input value is a valid category from this array. In such cases, you can add a `metadata` type to a form config and pass a value of this type to the `useForm` hook. Then all validators will receive an additional argument of this type on each invocation.
+Sometimes, to perform validation and return a proper type as an output you need something else besides a form state. For example, there is an array of categories `array<Category.t>` that comes from your server and you need to validate that input value is a valid category from this array. In such cases, you can add a `metadata` type to a form config and pass a value of this type to the `useForm` hook. Then all validators will receive an additional argument of this type on each invocation.
 
 ```reason
 module Category = {
@@ -9,7 +9,7 @@ module Category = {
   }
 };
 
-module Form = [%form
+module Form = %form(
   type input = {
     category: string,
   };
@@ -19,7 +19,7 @@ module Form = [%form
   };
 
   type metadata = {
-    categories: array(Category.t),
+    categories: array<Category.t>,
   };
 
   let validators = {
@@ -40,12 +40,12 @@ module Form = [%form
       },
     },
   };
-];
+);
 
 let initialInput = {category: ""};
 
-[@react.component]
-let make = (~categories: array(Category.t)) => {
+@react.component
+let make = (~categories: array<Category.t>) => {
   let form =
     Form.useForm(
       ~initialInput,

--- a/docs/09-FormSubmission.md
+++ b/docs/09-FormSubmission.md
@@ -2,9 +2,9 @@
 `Formality` keeps track of the whole form status which can be in the following states:
 
 ```reason
-type formStatus('submissionError) =
+type formStatus<'submissionError> =
   | Editing
-  | Submitting(option('submissionError))
+  | Submitting(option<'submissionError>)
   | Submitted
   | SubmissionFailed('submissionError);
 ```
@@ -15,15 +15,15 @@ As it's been shown in **[Basic Usage](./04-BasicUsage.md)** section, to trigger 
 `onSubmit` handler takes 2 arguments: `output` data and callbacks. Let's look into the latter.
 
 ```reason
-type submissionCallbacks('input, 'submissionError) = {
-  notifyOnSuccess: option('input) => unit,
+type submissionCallbacks<'input, 'submissionError> = {
+  notifyOnSuccess: option<'input> => unit,
   notifyOnFailure: 'submissionError => unit,
   reset: unit => unit,
   dismissSubmissionResult: unit => unit,
 };
 ```
 
-### `notifyOnSuccess: option('input) => unit`
+### `notifyOnSuccess: option<'input> => unit`
 This callback should be triggered after successful submission if you don't want to completely reset the form but set it to `Submitted` state preserving all internal statuses. Optionally, you can pass the next `input` that would replace the current one.
 
 ### `notifyOnFailure: 'submissionError => unit`
@@ -43,7 +43,7 @@ type submissionError =
   | UnexpectedServerError;
 ```
 
-Then, when a response from the server is received, you can pass one of those constructors to the `notifyOnFailure` and it will be available via `form.status` variant in `SubmissionFailed(submissionError)` constructor.
+Then, when a response from the server is received, you can pass one of those constructors to the `notifyOnFailure` and it will be available via `form.status` variant in `SubmissionFailed<submissionError>` constructor.
 
 If you don't need to parse submission errors in your form, skip this type and it would be set to `unit` under the hood:
 

--- a/docs/12-API.md
+++ b/docs/12-API.md
@@ -2,9 +2,9 @@
 
 - [Configuration](#configuration)
   - [`type input`](#type-input)
-    - [`[@field.async]`](#fieldasync)
-    - [`[@field.collection]`](#fieldcollection)
-    - [`[@field.deps]`](#fielddeps)
+    - [`@field.async`](#fieldasync)
+    - [`@field.collection`](#fieldcollection)
+    - [`@field.deps`](#fielddeps)
   - [`type output`](#type-output)
   - [`type message`](#type-message)
   - [`type metadata`](#metadata)
@@ -55,34 +55,34 @@ See **[IO](./03-IO.md)** & **[Basic Usage](./04-BasicUsage.md)**.
 <br>
 
 #### `input` field attributes
-##### `[@field.async]`
+##### `@field.async`
 **Requirements:** Optional.
 
 Attribute for a field with async validation.
 
 ```reason
-type input = {email: [@field.async] string};
+type input = {email: @field.async string};
 
 // OnChange mode
 // Default, use it if you want to be explicit.
-type input = {email: [@field.async {mode: OnChange}] string};
+type input = {email: @field.async({mode: OnChange}) string};
 
 // OnBlur mode
-type input = {email: [@field.async {mode: OnBlur}] string};
+type input = {email: @field.async({mode: OnBlur}) string};
 ```
 
 See **[Async Validation](./05-AsyncValidation.md)**.
 <br>
 <br>
 
-##### `[@field.collection]`
+##### `@field.collection`
 **Requirements:** Optional. If provided, must be an array.
 
 Attribute for a collection field.
 
 ```reason
-type input = {
-  authors: [@field.collection] array(author),
+type rec input = {
+  authors: @field.collection array<author>,
 }
 and author = {name: string};
 ```
@@ -91,14 +91,14 @@ See **[Collections](./06-Collections.md)**.
 <br>
 <br>
 
-##### `[@field.deps]`
+##### `@field.deps`
 **Requirements:** Optional.
 
 Dependent fields attribute.
 
 ```reason
 type input = {
-  a: [@field.deps b] string,
+  a: @field.deps(b) string,
   b: string,
 };
 ```
@@ -141,7 +141,7 @@ See **[Basic Usage](./04-BasicUsage.md)** & **[I18n](./10-I18n.md)**.
 Additional metadata.
 
 ```reason
-type metadata = { items: array(Item.t) };
+type metadata = { items: array<Item.t> };
 ```
 
 See **[Metadata](./08-Metadata.md)**.
@@ -189,50 +189,50 @@ let validators = {
   // General field
   field: {
     strategy: Strategy.t,
-    validate: input => result('outputValue, message),
+    validate: input => result<'outputValue, message>,
   },
 
   // Field of collection
   fieldOfCollection: {
-    collection: input => result(unit, message), // or None
+    collection: input => result<unit, message>, // or None
     fields: {
       strategy: Strategy.t,
-      validate: (input, ~at: int) => result('outputValue, message),
+      validate: (input, ~at: int) => result<'outputValue, message>,
     },
   },
 
   // Validator with `metadata`
   field: {
     strategy: Strategy.t,
-    validate: (input, metadata) => result('outputValue, message),
+    validate: (input, metadata) => result<'outputValue, message>,
   },
 
   // Async field
   asyncField: {
     strategy: Strategy.t,
-    validate: input => result('outputValue, message),
-    validateAsync: 'outputValue => Js.Promise.t(result('outputValue, message)),
+    validate: input => result<'outputValue, message>,
+    validateAsync: 'outputValue => Js.Promise.t<result<'outputValue, message>>,
   },
 
   // Async field of collection
   asyncFieldOfCollection: {
     strategy: Strategy.t,
-    validate: (input, ~at: int) => result('outputValue, message),
-    validateAsync: 'outputValue => Js.Promise.t(result('outputValue, message)),
+    validate: (input, ~at: int) => result<'outputValue, message>,
+    validateAsync: 'outputValue => Js.Promise.t<result<'outputValue, message>>,
   },
 
   // Async field with metadata
   asyncFieldWithEq: {
     strategy: Strategy.t,
-    validate: (input, metadata) => result('outputValue, message),
-    validateAsync: ('outputValue, metadata) => Js.Promise.t(result('outputValue, message)),
+    validate: (input, metadata) => result<'outputValue, message>,
+    validateAsync: ('outputValue, metadata) => Js.Promise.t<result<'outputValue, message>>,
   },
 
   // Async field with eq function
   asyncFieldWithEq: {
     strategy: Strategy.t,
-    validate: input => result('outputValue, message),
-    validateAsync: 'outputValue => Js.Promise.t(result('outputValue, message)),
+    validate: input => result<'outputValue, message>,
+    validateAsync: 'outputValue => Js.Promise.t<result<'outputValue, message>>,
     eq: ('outputValue, 'outputValue) => bool,
   },
 
@@ -246,7 +246,7 @@ See **[Validation Strategies](./02-ValidationStrategies.md)**, **[Basic Usage](.
 <br>
 
 ## Rendering
-Module created via `[%form]` extension exposes `useForm` React hook.
+Module created via `%form` extension exposes `useForm` React hook.
 
 ### `useForm`
 React hook.
@@ -271,7 +271,7 @@ Callbacks passed to `onSubmit` handler.
 
 ```reason
 type submissionCallbacks = {
-  notifyOnSuccess: option(input) => unit,
+  notifyOnSuccess: option<input> => unit,
   notifyOnFailure: submissionError => unit,
   reset: unit => unit,
   dismissSubmissionResult: unit => unit,
@@ -288,7 +288,7 @@ Interface to the hook.
 ```reason
 type interface = {
   input: input,
-  status: Formality.formStatus(submissionError),
+  status: Formality.formStatus<submissionError>,
   submitting: bool,
   dirty: unit => bool,
   submit: unit => unit,
@@ -300,22 +300,22 @@ type interface = {
   // General form
   valid: unit => bool,
   // Form with async fields
-  valid: unit => option(bool),
+  valid: unit => option<bool>,
 
   // General field
   update[Field]: ((input, 'inputValue) => input, 'inputValue) => unit,
   blur[Field]: unit => unit,
-  [field]Result: option(result('outputValue, message)),
+  [field]Result: option<result<'outputValue, message>>,
 
   // Async field
   update[Field]: ((input, 'inputValue) => input, 'inputValue) => unit,
   blur[Field]: unit => unit,
-  [field]Result: option(Formality.Async.exposedFieldStatus('outputValue, message)),
+  [field]Result: option<Formality.Async.exposedFieldStatus<'outputValue, message>>,
 
   // Field of collection
   update[CollectionEntry][Field]: (~at: index, (input, 'inputValue) => input, 'inputValue) => unit,
   blur[CollectionEntry][Field]: (~at: index) => unit,
-  [collectionEntry][Field]Result: (~at: index) => option(result('outputValue, message)),
+  [collectionEntry][Field]Result: (~at: index) => option<result<'outputValue, message>>,
 
   // Collection
   add[CollectionEntry]: 'collectionEntryInput => unit,
@@ -353,17 +353,17 @@ Used to display validation result for a specific field.
 
 ```reason
 // Field
-[field]Result: option(result('outputValue, message)),
+[field]Result: option<result<'outputValue, message>>,
 
 // Async field
 type asyncResult =
   | Validating('outputValue)
-  | Result(result('outputValue, message));
+  | Result(result<'outputValue, message>);
 
-[field]Result: option(asyncResult),
+[field]Result: option<asyncResult>,
 
 // Field of collection
-[collectionEntry][Field]Result: (~at: index) => option(result('outputValue, message)),
+[collectionEntry][Field]Result: (~at: index) => option<result<'outputValue, message>>,
 ```
 <br>
 
@@ -393,7 +393,7 @@ Current form status.
 ```reason
 type formStatus =
   | Editing
-  | Submitting(option(MyForm.submissionError))
+  | Submitting(option<MyForm.submissionError>)
   | Submitted
   | SubmissionFailed(MyForm.submissionError);
 
@@ -460,7 +460,7 @@ reset: unit => unit
 #### `valid`
 The function that would report the overall validity of the form.
 
-In forms with async fields, it would return `option(bool)`. `None` is possible when one of the async fields in `Validating` state, i.e. we don't know yet if it's valid or not. Also, keep in mind, if one of the async fields wasn't touched yet, it would perform only local validation.
+In forms with async fields, it would return `option<bool>`. `None` is possible when one of the async fields in `Validating` state, i.e. we don't know yet if it's valid or not. Also, keep in mind, if one of the async fields wasn't touched yet, it would perform only local validation.
 
 Use this function with caution since it might introduce noticeable overhead on large forms.
 
@@ -469,5 +469,5 @@ Use this function with caution since it might introduce noticeable overhead on l
 valid: unit => bool
 
 // Form with async fields
-valid: unit => option(bool)
+valid: unit => option<bool>
 ```


### PR DESCRIPTION
Hi there 👋

I was reading the docs and noticed some syntax was out of date so I made a few changes that do the following:
1. replaces type wrappers using () with <> ```option('type) -> option<'type>```
2. changes form ppx extension syntax with from being wrapped in [] to wrapping with (): ```[%form ...]; -> %form(...)```
3. removes [] from wrapping attributes: ```[@react.component] -> @react.component```
and with args i.e. an input type: ```[field]: @field.async(mode: OnBlur) string,```
6. adds the `rec` keyword where missing to type examples that are followed by `and type = ...`

I took into account https://github.com/shakacode/re-formality/pull/119 and did not make the same changes they already did